### PR TITLE
conda-recipe: Specify explicit build number

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
   path: ../
 
 build:
+  number: 0
   string: py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
 
 requirements:


### PR DESCRIPTION
Apparently in newer versions of conda, the `{{PKG_BUILDNUM}}` magic doesn't work unless the `build:number` is explicitly stated in `meta.yaml`.